### PR TITLE
Loosen formatting restrictions.

### DIFF
--- a/src/main/kotlin/at/hannibal2/changelog/SkyHanniChangelogBuilder.kt
+++ b/src/main/kotlin/at/hannibal2/changelog/SkyHanniChangelogBuilder.kt
@@ -14,9 +14,23 @@ object SkyHanniChangelogBuilder {
     private val gson by lazy { GsonBuilder().setPrettyPrinting().create() }
 
     private val categoryPattern = "## Changelog (?<category>.+)".toPattern()
-    private val changePattern = "\\+ (?<text>.+?) - (?<author>.+)".toPattern()
-    private val changePatternNoAuthor = "\\+ (?<text>.+)".toPattern()
-    private val extraInfoPattern = " {4}\\* (?<text>.+)".toPattern()
+
+    /**
+     * REGEX-TEST: + Change. - Author
+     * REGEX-TEST: - Change. - Author
+     * REGEX-TEST: * Change. - Author
+     */
+    private val changePattern = "^[*+-] (?<text>.+?) - (?<author>.+)".toPattern()
+    private val changePatternNoAuthor = "^[*+-] (?<text>.+)".toPattern()
+
+    /**
+     * REGEX-TEST:     * Extra info
+     * REGEX-TEST:     + Extra info
+     * REGEX-TEST: 	- Extra info
+     * REGEX-TEST:   + Extra info
+     * REGEX-TEST:   - Extra info
+     */
+    private val extraInfoPattern = "(?: {2,4}|\\t)[*+-] (?<text>.+)".toPattern()
     private val prTitlePattern = "(?<prefix>.+): (?<title>.+)".toPattern()
     private val illegalStartPattern = "^[-=*+ ].*".toPattern()
 

--- a/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
+++ b/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
@@ -257,7 +257,7 @@ class SkyHanniChangelogBuilderTest {
         val prBody = listOf(
             "## Changelog Technical Details",
             "+ Backend change with a plus. - Author",
-            "   * More info with tab and asterisk.",
+            "\t* More info with tab and asterisk.",
             "  + More info with 2 spaces and plus.",
             "- Backend change with a minus. - Author",
             "    - More info with 4 spaces and minus.",

--- a/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
+++ b/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
@@ -266,9 +266,6 @@ class SkyHanniChangelogBuilderTest {
 
         val (changes, errors) = SkyHanniChangelogBuilder.findChanges(prBody, prLink)
 
-        println("changes: ${changes.map { it.text }}")
-        println("errors: ${errors.map { it.message }}")
-
         assertTrue(errors.isEmpty(), "Expected no errors")
     }
 }

--- a/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
+++ b/src/test/kotlin/SkyHanniChangelogBuilderTest.kt
@@ -251,4 +251,24 @@ class SkyHanniChangelogBuilderTest {
         assertEquals(1, pullRequestTitleErrors.size, "Expected one error")
         assertEquals("PR title must include category 'Fix' if there are any fixes in the PR", pullRequestTitleErrors[0].message)
     }
+
+    @Test
+    fun `test different formatting tokens`() {
+        val prBody = listOf(
+            "## Changelog Technical Details",
+            "+ Backend change with a plus. - Author",
+            "   * More info with tab and asterisk.",
+            "  + More info with 2 spaces and plus.",
+            "- Backend change with a minus. - Author",
+            "    - More info with 4 spaces and minus.",
+        )
+        val prLink = "https://example.com/pr/1"
+
+        val (changes, errors) = SkyHanniChangelogBuilder.findChanges(prBody, prLink)
+
+        println("changes: ${changes.map { it.text }}")
+        println("errors: ${errors.map { it.message }}")
+
+        assertTrue(errors.isEmpty(), "Expected no errors")
+    }
 }


### PR DESCRIPTION
Loosens the exact tokens that have to be used when formatting the changelog (i.e., you can now use `-`, `+`, or `*` to denote a bullet, as they all format the same.

Patterns remain functional for detection.